### PR TITLE
Replaced calls for IntLlib's global variable

### DIFF
--- a/food_basic/ingredients.lua
+++ b/food_basic/ingredients.lua
@@ -8,7 +8,7 @@
 
 -- Boilerplate to support localized strings if intllib mod is installed.
 local S = 0
-if (intllib) then
+if rawget(_G, "intllib") then
 	dofile(minetest.get_modpath("intllib").."/intllib.lua")
 	S = intllib.Getter(minetest.get_current_modname())
 else

--- a/food_basic/init.lua
+++ b/food_basic/init.lua
@@ -13,7 +13,7 @@ dofile(minetest.get_modpath("food_basic").."/ingredients.lua")
 
 -- Boilerplate to support localized strings if intllib mod is installed.
 local S = 0
-if (intllib) then
+if rawget(_G, "intllib") then
 	dofile(minetest.get_modpath("intllib").."/intllib.lua")
 	S = intllib.Getter(minetest.get_current_modname())
 else


### PR DESCRIPTION
Even if it's a really tiny modification, I did it as I promised.
At the beginning of the files, when the mod looks for intllibs, it does it by looking for
a variable defined by the library, but when the intllib mod isn't loaded, it ends up calling
for a global variable. Here is a more clean way to check whether or not the variable exists
using a lua function instead of a call for this variable.
(This is the PR we were talking about in #19 )